### PR TITLE
Update base.py in order to fix web2py-issues/697

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -1342,7 +1342,10 @@ class BaseAdapter(ConnectionPool):
             elif not isinstance(obj, (list, tuple)):
                 obj = [obj]
             if field_is_type('list:string'):
-                obj = map(lambda x:unicode(x).encode(self.db_codec),obj)
+                try:
+                    obj = map(str,obj)
+                except UnicodeEncodeError:
+                    obj = map(lambbda x:unicode(x).encode(self.db_codec),obj)
             else:
                 obj = map(int,[o for o in obj if o != ''])
         # we don't want to bar_encode json objects


### PR DESCRIPTION
This is an addition to the prior fix that introduces a problem with the incoming list objects are already strings. By wrapping the code in a try/except where looking specifically for a UnicodeEncodeError we maintain the existing code in all cases except when an actual error is generated. This should reduce the possibility of carry-on problems.
